### PR TITLE
Fix removal when tokens missing

### DIFF
--- a/server.js
+++ b/server.js
@@ -121,15 +121,16 @@ app.post("/remove-metadata", async (req, res) => {
         const userId = req.body.userId;
         const tokens = await storage.getDiscordTokens(userId);
 
-        if (!tokens) {
-            console.error(`No tokens found for user ${userId}`);
-            return res.sendStatus(404);
-        }
-
         const user = await getUser(userId);
         if (!user) {
             console.error(`User ${userId} not found in database`);
             return res.sendStatus(404);
+        }
+
+        if (!tokens) {
+            console.warn(
+                `No tokens found for user ${userId}. Skipping Discord metadata removal.`
+            );
         }
 
         const metadata = {
@@ -140,8 +141,10 @@ app.post("/remove-metadata", async (req, res) => {
             is_contributor: false,
         };
 
-        console.log(`📡 Removing metadata for ${userId}`);
-        await discord.pushMetadata(userId, tokens, metadata);
+        if (tokens) {
+            console.log(`📡 Removing metadata for ${userId}`);
+            await discord.pushMetadata(userId, tokens, metadata);
+        }
 
         console.log(`🗑️ Attempting to remove user from database: ${userId}`);
         const result = await db.collection("users").deleteOne({

--- a/storage.js
+++ b/storage.js
@@ -1,14 +1,18 @@
-const store = new Map();
+import { db } from "./database.js";
+
+// Persist tokens in MongoDB instead of memory
 
 export async function storeDiscordTokens(userId, tokens) {
-    await store.set(`discord-${userId}`, tokens);
+    await db
+        .collection("tokens")
+        .updateOne({ userId }, { $set: { tokens } }, { upsert: true });
 }
 
 export async function getDiscordTokens(userId) {
-    return store.get(`discord-${userId}`);
+    const entry = await db.collection("tokens").findOne({ userId });
+    return entry ? entry.tokens : null;
 }
 
 export async function deleteDiscordTokens(userId) {
-    const key = `discord-${userId}`;
-    await store.delete(key);
+    await db.collection("tokens").deleteOne({ userId });
 }


### PR DESCRIPTION
## Summary
- store Discord tokens in MongoDB
- allow `/remove-metadata` to succeed even when tokens are missing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685b16a7edb883299f76ca871eaec772